### PR TITLE
fix: rescue our beloved pets from the digital slaughterhouse 🐱➡️🐄

### DIFF
--- a/dev/book/src/Dendritic.md
+++ b/dev/book/src/Dendritic.md
@@ -128,7 +128,7 @@ And any file inside modules can contribute to flake outputs (packages/checks/osC
 ```nix
 # modules/flake/formatter.nix
 {
-  petSystem = {pkgs, ...}: {
+  perSystem = {pkgs, ...}: {
     formatter = pkgs.alejandra;
   };
 }


### PR DESCRIPTION
Turns out our flake-parts module was accidentally treating systems as "petSystem" instead of "perSystem" - which sounds adorable but sadly doesn't compile!

In the spirit of Infrastructure as Cattle (not Pets), we should probably be using perSystem anyway. But let's be honest, in a vegan DevOps world, we'd call it "perTofuSystem" and our infrastructure would be both cruelty-free AND reproducible! 🌱

Though I have to admit, the idea of each system having its own little digital pet name was kind of endearing... RIP petSystem, you were too pure for this world. 😿

Now our formatter can actually format things instead of just looking cute in the config file.